### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/crutch.js
+++ b/crutch.js
@@ -23,7 +23,7 @@ module.exports = function crutch(defaultOptions, callback) {
         app: _.bindAll(new events.EventEmitter()),
         defaultOptions: defaultOptions,
         Promise: Promise,
-        uuid: require('node-uuid'),
+        uuid: require('uuid'),
         serializer: require('./serializer.js'),
         'qtort-microservices': microservices,
     }, defaultOptions.injectables));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "~4.13.1",
     "log4js": "^0.6.36",
     "minimist": "~1.2.0",
-    "node-uuid": "~1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^2.5.3",

--- a/test/moduleTests.js
+++ b/test/moduleTests.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var should = require('should');
 var sinon = require('sinon');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 describe('module', function() {
     var a = { 1: 1 }, b = { 2: 2 }, c = { 3: 3 }, d = { 4: 4 };

--- a/test/transport-amqpTests.js
+++ b/test/transport-amqpTests.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var Promise = require('bluebird')
 var sinon = require('sinon');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var AmqpTransport = require('../transport-amqp.js');
 

--- a/transport-amqp.js
+++ b/transport-amqp.js
@@ -36,7 +36,7 @@ function AmqpTransport(options, _, amqplib, Promise, serializer, uuid) {
     amqplib = amqplib || require('amqplib');
     Promise = Promise || require('bluebird');
     serializer = serializer || require('./serializer');
-    uuid = uuid || require('node-uuid');
+    uuid = uuid || require('uuid');
 
     /**
      * Binds an endpoint at the specified address.

--- a/transport.js
+++ b/transport.js
@@ -2,7 +2,7 @@
 
 var events = require('events');
 var util = require('util');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 /**
  * Provides a skeleton for transports used with the micro-services module.


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.